### PR TITLE
Disable/enable pan or zoom individually.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,17 +68,33 @@ function panZoom (target, cb) {
 	var isPassive = [window, document, document.documentElement, document.body].indexOf(target) >= 0
 
 	//enable zooming
-	var wheelListener = wheel(target, function (dx, dy, dz, e) {
-		if (!isPassive) e.preventDefault()
-		schedule({
-			srcElement: e.srcElement,
-			target: target,
-			type: 'mouse',
-			dx: 0, dy: 0, dz: dy,
-			x: touch.position[0], y: touch.position[1],
-			x0: touch.position[0], y0: touch.position[1]
-		})
-	})
+  var wheelListener = null;
+  function enableMouseWheel() {
+    if (!wheelListener) {
+      return wheel(target, function (dx, dy, dz, e) {
+        if (!isPassive) e.preventDefault();
+        schedule({
+          srcElement: e.srcElement,
+          target: target,
+          type: 'mouse',
+          dx: 0, dy: 0, dz: dy,
+          x: touch.position[0], y: touch.position[1],
+          x0: touch.position[0], y0: touch.position[1]
+        })
+      });
+    } else {
+      return wheelListener;
+    }
+  }
+
+  function disableMouseWheel() {
+    if (wheelListener) {
+      target.removeEventListener('wheel', wheelListener);
+      wheelListener = null;
+    }
+  }
+
+  wheelListener = enableMouseWheel();
 
 	//mobile pinch zoom
 	var pinch = touchPinch(target)
@@ -149,18 +165,38 @@ function panZoom (target, cb) {
 		})
 	}
 
-	return function unpanzoom () {
-		touch.dispose()
+  let unpanzoom = function () {
+    touch.dispose();
 
-		target.removeEventListener('mousedown', initFn)
-		target.removeEventListener('touchstart', initFn)
+    target.removeEventListener('mousedown', initFn);
+    target.removeEventListener('touchstart', initFn);
 
-		impetus.destroy()
+    impetus.destroy();
 
-		target.removeEventListener('wheel', wheelListener)
+    disableMouseWheel();
 
-		pinch.disable()
+    pinch.disable();
 
-		raf.cancel(frameId)
-	}
+    raf.cancel(frameId);
+  };
+
+  unpanzoom.disablePan = function() {
+    impetus && impetus.pause();
+  };
+
+  unpanzoom.enablePan = function() {
+    impetus && impetus.resume();
+  };
+
+  unpanzoom.disableZoom = function() {
+    pinch && pinch.disable();
+    disableMouseWheel();
+  };
+
+  unpanzoom.enableZoom = function() {
+    pinch && pinch.enable();
+    wheelListener = enableMouseWheel();
+  };
+
+  return unpanzoom;
 }

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ function panZoom (target, cb) {
 		})
 	}
 
-	let unpanzoom = function () {
+	var unpanzoom = function () {
 		touch.dispose();
 
 		target.removeEventListener('mousedown', initFn);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * @module	pan-zoom
+ * @module  pan-zoom
  *
  * Events for pan and zoom
  */

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /**
- * @module  pan-zoom
+ * @module	pan-zoom
  *
  * Events for pan and zoom
  */
@@ -68,33 +68,33 @@ function panZoom (target, cb) {
 	var isPassive = [window, document, document.documentElement, document.body].indexOf(target) >= 0
 
 	//enable zooming
-  var wheelListener = null;
-  function enableMouseWheel() {
-    if (!wheelListener) {
-      return wheel(target, function (dx, dy, dz, e) {
-        if (!isPassive) e.preventDefault();
-        schedule({
-          srcElement: e.srcElement,
-          target: target,
-          type: 'mouse',
-          dx: 0, dy: 0, dz: dy,
-          x: touch.position[0], y: touch.position[1],
-          x0: touch.position[0], y0: touch.position[1]
-        })
-      });
-    } else {
-      return wheelListener;
-    }
-  }
+	var wheelListener = null;
+	function enableMouseWheel() {
+		if (!wheelListener) {
+			return wheel(target, function (dx, dy, dz, e) {
+				if (!isPassive) e.preventDefault();
+				schedule({
+					srcElement: e.srcElement,
+					target: target,
+					type: 'mouse',
+					dx: 0, dy: 0, dz: dy,
+					x: touch.position[0], y: touch.position[1],
+					x0: touch.position[0], y0: touch.position[1]
+				})
+			});
+		} else {
+			return wheelListener;
+		}
+	}
 
-  function disableMouseWheel() {
-    if (wheelListener) {
-      target.removeEventListener('wheel', wheelListener);
-      wheelListener = null;
-    }
-  }
+	function disableMouseWheel() {
+		if (wheelListener) {
+			target.removeEventListener('wheel', wheelListener);
+			wheelListener = null;
+		}
+	}
 
-  wheelListener = enableMouseWheel();
+	wheelListener = enableMouseWheel();
 
 	//mobile pinch zoom
 	var pinch = touchPinch(target)
@@ -165,38 +165,38 @@ function panZoom (target, cb) {
 		})
 	}
 
-  let unpanzoom = function () {
-    touch.dispose();
+	let unpanzoom = function () {
+		touch.dispose();
 
-    target.removeEventListener('mousedown', initFn);
-    target.removeEventListener('touchstart', initFn);
+		target.removeEventListener('mousedown', initFn);
+		target.removeEventListener('touchstart', initFn);
 
-    impetus.destroy();
+		impetus.destroy();
 
-    disableMouseWheel();
+		disableMouseWheel();
 
-    pinch.disable();
+		pinch.disable();
 
-    raf.cancel(frameId);
-  };
+		raf.cancel(frameId);
+	};
 
-  unpanzoom.disablePan = function() {
-    impetus && impetus.pause();
-  };
+	unpanzoom.disablePan = function() {
+		impetus && impetus.pause();
+	};
 
-  unpanzoom.enablePan = function() {
-    impetus && impetus.resume();
-  };
+	unpanzoom.enablePan = function() {
+		impetus && impetus.resume();
+	};
 
-  unpanzoom.disableZoom = function() {
-    pinch && pinch.disable();
-    disableMouseWheel();
-  };
+	unpanzoom.disableZoom = function() {
+		pinch && pinch.disable();
+		disableMouseWheel();
+	};
 
-  unpanzoom.enableZoom = function() {
-    pinch && pinch.enable();
-    wheelListener = enableMouseWheel();
-  };
+	unpanzoom.enableZoom = function() {
+		pinch && pinch.enable();
+		wheelListener = enableMouseWheel();
+	};
 
-  return unpanzoom;
+	return unpanzoom;
 }

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,13 @@ let unpanzoom = panzoom(document.body, e => {
   e.y0;
 });
 
-// call to remove panzoom handler from the target
+// you can pause/resume pan or zoom functionality at runtime if you ever need.
+unpanzoom.disablePan()
+unpanzoom.disableZoom()
+unpanzoom.enablePan()
+unpanzoom.enableZoom()
+
+// call to completely remove panzoom handler from the target
 unpanzoom()
 ```
 


### PR DESCRIPTION
### What does this PR do?

Updates the API to allow users to disable or enable panning or zooming individually. This is useful if implementing a UI where the user needs to drag map pins on a map. In this situation, it can be useful to disable panning when the user hovers a map pin and then re-enable panning once the mouse leaves the map pin.

I tried to make this API backwards compatible by adding the enable/disable methods as properties on the returned destroy function.