### PR TITLE
Completely remove raf

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,6 @@ function panZoom (target, cb) {
 
 		pinch.disable()
 
-		raf.cancel(frameId)
+		window.cancelAnimationFrame(frameId)
 	}
 }


### PR DESCRIPTION
in 66c0dd9c4fa40ff003c259f24f74bb1c4ffed9ac raf was removed but it was still called in unpanzoom().